### PR TITLE
Fixing Port and Introducing PORT Variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 XDAI_RPC_URL=https://dai.poa.network
 PUBLIC_IP=x.x.x.x
+PORT=9000
 LOG_LEVEL=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --http-address 127.0.0.1
       --http
       --enr-address $PUBLIC_IP
-      --enr-udp-port 12000
+      --enr-udp-port $PORT
       --debug-level $LOG_LEVEL
     network_mode: host
     volumes:
@@ -28,8 +28,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata
@@ -53,8 +53,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata


### PR DESCRIPTION
Fixing the default port of Lighthouse to 9000, while enabling custom `PORT` via editing `.env`.