### PR TITLE
Ignore runtime files, add port variables, and add graffiti support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
-XDAI_RPC_URL=https://dai.poa.network
-PUBLIC_IP=x.x.x.x
+DISCOVERY_PORT=12000
+ENR_UDP_PORT=12000
 LOG_LEVEL=info
+PORT=13000
+PUBLIC_IP=x.x.x.x
+XDAI_RPC_URL=https://dai.poa.network

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+.env
 .idea/
+config/graffiti_file.txt
+keys/keystore_password.txt
+keys/validator_keys
+node_db/
+validators/

--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ git clone https://github.com/gnosischain/lighthouse-launch .
 3) Copy all validators keystore files to the `./keys/validator_keys` directory. Ensure that copied keystores are only used on a single VM instance.
 4) Write keystore password to the `./keys/keystore_password.txt` file
 5) Create `.env` file from the example at `.env.example`. Put the valid external IP address of your VM and xDAI RPC url in the config. Other values can be left without changes.
+6) (Optional) Create `./config/graffiti_file.txt` from the example at `./config/graffiti_file.txt.example`. Update with your prefered default graffiti and any validator specific graffiti values you'd like.
 
 If it is required to send the node and validator logs to a remote syslog server the following actions can be done (it is assumed that the node and validator will be run by using the `docker-compose-syslog.yml` file with the `docker-compose` command in the instructions below).
 
-6) Copy `./syslog/etc/logrotate.d/docker-logs` to `/etc/logrotate.d/`.
-7) Copy `./syslog/etc/rsyslog.d/30-gbc-local.conf` and `./syslog/etc/rsyslog.d/35-gbc-remote-logging.conf` to `/etc/rsyslog.d/`.
-8) Modify `target` and `port` in `/etc/rsyslog.d/35-gbc-remote-logging.conf` to point to a remote syslog server.
-9) Restart the rsyslog service by `systemctl restart rsyslog`.
+7) Copy `./syslog/etc/logrotate.d/docker-logs` to `/etc/logrotate.d/`.
+8) Copy `./syslog/etc/rsyslog.d/30-gbc-local.conf` and `./syslog/etc/rsyslog.d/35-gbc-remote-logging.conf` to `/etc/rsyslog.d/`.
+9) Modify `target` and `port` in `/etc/rsyslog.d/35-gbc-remote-logging.conf` to point to a remote syslog server.
+10) Restart the rsyslog service by `systemctl restart rsyslog`.
 
 ## Import of validator keys
 1) Run the following command to import and all added keystore files:

--- a/config/graffiti_file.txt.example
+++ b/config/graffiti_file.txt.example
@@ -1,0 +1,3 @@
+default: default_graffiti
+public_key1: graffiti1
+public_key2: graffiti2

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -5,14 +5,14 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --http-address 127.0.0.1
       --http
       --enr-address $PUBLIC_IP
-      --enr-udp-port 12000
+      --enr-udp-port $ENR_UDP_PORT
       --debug-level $LOG_LEVEL
     network_mode: host
     volumes:
@@ -26,8 +26,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata
@@ -49,8 +49,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -88,6 +88,7 @@ services:
       --testnet-dir /root/sbc/config
       --validators-dir /root/sbc/validators
       --beacon-nodes http://localhost:5052
+      --graffiti-file /root/sbc/config/graffiti_file.txt
     network_mode: host
     volumes:
       - ./config:/root/sbc/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --http-address 127.0.0.1
       --http
       --enr-address $PUBLIC_IP
-      --enr-udp-port 12000
+      --enr-udp-port $ENR_UDP_PORT
       --debug-level $LOG_LEVEL
     network_mode: host
     volumes:
@@ -28,8 +28,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata
@@ -53,8 +53,8 @@ services:
     command: |
       lighthouse beacon_node
       --testnet-dir /root/sbc/config
-      --discovery-port 12000
-      --port 13000
+      --discovery-port $DISCOVERY_PORT
+      --port $PORT
       --eth1-endpoints $XDAI_RPC_URL
       --datadir /home/.eth2/beaconchaindata
       --slasher-dir /home/.eth2/slasherdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       --testnet-dir /root/sbc/config
       --validators-dir /root/sbc/validators
       --beacon-nodes http://localhost:5052
+      --graffiti-file /root/sbc/config/graffiti_file.txt
     network_mode: host
     volumes:
       - ./config:/root/sbc/config


### PR DESCRIPTION
Adds 3 updates that I wanted for my own setup:

* Git ignore run time and sensitive files
* Allow ports to be configured with env variables
* Allow an optional graffiti file

Is this of interest to the general repo as well?