### PR TITLE
Value for total peers increased

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 XDAI_RPC_URL=https://rpc.gnosischain.com
 PUBLIC_IP=x.x.x.x
+TARGET_PEERS=80
 LOG_LEVEL=info

--- a/docker-compose-local-logs.yml
+++ b/docker-compose-local-logs.yml
@@ -15,6 +15,7 @@ services:
       --http
       --enr-address $PUBLIC_IP
       --enr-udp-port 12000
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *
@@ -43,6 +44,7 @@ services:
       --slasher-dir /home/.eth2/slasherdata
       --http-address 0.0.0.0
       --http
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *
@@ -74,6 +76,7 @@ services:
       --slasher-dir /home/.eth2/slasherdata
       --http-address 0.0.0.0
       --http
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -15,6 +15,7 @@ services:
       --http
       --enr-address $PUBLIC_IP
       --enr-udp-port 12000
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *
@@ -41,6 +42,7 @@ services:
       --slasher-dir /home/.eth2/slasherdata
       --http-address 0.0.0.0
       --http
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *
@@ -70,6 +72,7 @@ services:
       --slasher-dir /home/.eth2/slasherdata
       --http-address 0.0.0.0
       --http
+      --target-peers $TARGET_PEERS
       --metrics
       --metrics-address 0.0.0.0
       --metrics-allow-origin *


### PR DESCRIPTION
Since the usual scenario for LH nodes in GBC is to have hundreds of validators public key the LH team recommends to increase the total peers in the node configuration to handle more subnets subscribed by validators.