### PR TITLE
Enable fast sync and doppelganger protection

### DIFF
--- a/docker-compose-local-logs.yml
+++ b/docker-compose-local-logs.yml
@@ -7,6 +7,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -37,6 +38,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -69,6 +71,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -116,6 +119,7 @@ services:
     command: |
       lighthouse validator_client
       --network gnosis
+      --enable-doppelganger-protection
       --validators-dir /root/sbc/validators
       --beacon-nodes http://node:5052
       --graffiti-file /root/sbc/config/graffiti.yml

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -7,6 +7,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -35,6 +36,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -65,6 +67,7 @@ services:
     command: |
       lighthouse beacon_node
       --network gnosis
+      --checkpoint-sync-url https://rpc-gbc.gnosischain.com/
       --discovery-port 12000
       --port 13000
       --eth1-endpoints $XDAI_RPC_URL
@@ -110,6 +113,7 @@ services:
     command: |
       lighthouse validator_client
       --network gnosis
+      --enable-doppelganger-protection
       --validators-dir /root/sbc/validators
       --beacon-nodes http://node:5052
       --graffiti-file /root/sbc/config/graffiti.yml


### PR DESCRIPTION
1. Enable of the fast sync (by using RPC API) impacts works for the first run of the service only. After subsequent restart, p2p is used to get the latest state.
2. The doppelganger protection delays the validator client runs. It is not only more safe way for the service restart but also allows the beacon node to discover sufficient number of peers.