### PR TITLE
LH 2.2.0 usage to export/import slashing db as well

### DIFF
--- a/docker-compose-local-logs.yml
+++ b/docker-compose-local-logs.yml
@@ -136,7 +136,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-import-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.0-modern
     command: |
       lighthouse account validator slashing-protection import
       --network gnosis
@@ -151,7 +151,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-export-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.0-modern
     command: |
       lighthouse account validator slashing-protection export
       --network gnosis

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -130,7 +130,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-import-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.0-modern
     command: |
       lighthouse account validator slashing-protection import
       --network gnosis
@@ -145,7 +145,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-export-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.0-modern
     command: |
       lighthouse account validator slashing-protection export
       --network gnosis


### PR DESCRIPTION
Due to a code merge issue the release 2.1.5 was still used in docker-compose files for exporting/importing the slashing db. This PR addresses the issue.