### PR TITLE
Bump Lighthouse to v2.2.1

### DIFF
--- a/config/graffiti.yml
+++ b/config/graffiti.yml
@@ -1,1 +1,1 @@
-default: Lighthouse/v2.2.0-bac7c3f
+default: Lighthouse/v2.2.1-aa72088

--- a/docker-compose-local-logs.yml
+++ b/docker-compose-local-logs.yml
@@ -151,7 +151,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-export-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account validator slashing-protection export
       --network gnosis

--- a/docker-compose-local-logs.yml
+++ b/docker-compose-local-logs.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   node:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -32,7 +32,7 @@ services:
         max-size: "100m"
         max-file: "1"
   node-private-slasher:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -65,7 +65,7 @@ services:
         max-size: "100m"
         max-file: "1"
   node-public-slasher:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -99,7 +99,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-import:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account_manager validator import
       --network gnosis
@@ -111,7 +111,7 @@ services:
       - ./keys:/root/sbc/keys
       - ./validators:/root/sbc/validators
   validator:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: validator
     restart: always
     depends_on:
@@ -136,7 +136,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-import-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account validator slashing-protection import
       --network gnosis

--- a/docker-compose-syslog.yml
+++ b/docker-compose-syslog.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   node:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -30,7 +30,7 @@ services:
       driver: syslog
       options: { tag: '{{.Name}}/{{.ID}}' }
   node-private-slasher:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -61,7 +61,7 @@ services:
       driver: syslog
       options: { tag: '{{.Name}}/{{.ID}}' }
   node-public-slasher:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: node
     restart: always
     command: |
@@ -93,7 +93,7 @@ services:
       driver: syslog
       options: { tag: '{{.Name}}/{{.ID}}' }
   validator-import:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account_manager validator import
       --network gnosis
@@ -105,7 +105,7 @@ services:
       - ./keys:/root/sbc/keys
       - ./validators:/root/sbc/validators
   validator:
-    image: sigp/lighthouse:v2.2.0-modern
+    image: sigp/lighthouse:v2.2.1-modern
     hostname: validator
     restart: always
     depends_on:
@@ -130,7 +130,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-import-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account validator slashing-protection import
       --network gnosis
@@ -145,7 +145,7 @@ services:
         max-size: "100m"
         max-file: "1"
   validator-export-slashing-protection:
-    image: sigp/lighthouse:v2.1.5-modern
+    image: sigp/lighthouse:v2.2.1-modern
     command: |
       lighthouse account validator slashing-protection export
       --network gnosis


### PR DESCRIPTION
Release notes on LH repo: https://github.com/sigp/lighthouse/releases/tag/v2.2.1

This release fixes a bug in Lighthouse v2.2.0 that prevented some nodes from completing sync when syncing from genesis block.